### PR TITLE
Fix missing jQuery

### DIFF
--- a/graphs.html
+++ b/graphs.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="d3.v2.min.js"></script>
 	    <link href="css/bootstrap.css" rel="stylesheet">
 		<link href="css/jquery.jqplot.min.css" rel="stylesheet">
-		<script src="http://twitter.github.com/bootstrap/assets/js/jquery.js"></script>
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 		<script src="js/bootstrap.min.js"></script>
 		<script language="javascript" type="text/javascript" src="js/jquery.jqplot.min.js"></script>
 		<script class="include" language="javascript" type="text/javascript" src="js/jqplot.pieRenderer.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="d3.v2.min.js"></script>
 	    <link href="css/bootstrap.css" rel="stylesheet">
 		<link href="css/jquery.jqplot.min.css" rel="stylesheet">
-		<script src="http://twitter.github.com/bootstrap/assets/js/jquery.js"></script>
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 		<script src="js/bootstrap.min.js"></script>
 		<script language="javascript" type="text/javascript" src="js/jquery.jqplot.min.js"></script>
 		<script class="include" language="javascript" type="text/javascript" src="js/jqplot.pieRenderer.min.js"></script>


### PR DESCRIPTION
Previous jQuery link is no longer available.

Switched to google api hosted jQuery 1.10.2 to restore functionality.
